### PR TITLE
Fix `set the host-home-xdg` url

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ Please see the upstream Fisher documentation section titled, "[Getting started](
 
 ## Auto install of Fisher packages
 
-This plugin will automatically run Fisher if it finds a `fishfile` that is not empty and the `local` directory has not yet been created by Fisher. By default the `fishfile` is located at `~/.xxh/config/fish/fishfile` and the `local` directory is located at `~/.xxh/config/fisher/local`. Note that these locations will be different if you [set the host-home-xdg with ](https://github.com/xxh/xxh#how-to-set-homeuser-as-home-instead-of-homeuserxxh)`+hhx`. 
+This plugin will automatically run Fisher if it finds a `fishfile` that is not empty and the `local` directory has not yet been created by Fisher. By default the `fishfile` is located at `~/.xxh/config/fish/fishfile` and the `local` directory is located at `~/.xxh/config/fisher/local`. Note that these locations will be different if you [set the host-home-xdg with ](https://github.com/xxh/xxh/wiki#how-to-set-homeuser-as-home-on-host)`+hhx`. 


### PR DESCRIPTION
The link was dead and here is the fix of it.